### PR TITLE
Fix typing error in doc

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -32,7 +32,7 @@ From pypi
 
 With pip::
 
-   $ pip install woomF
+   $ pip install woom
 
 From sources
 ------------


### PR DESCRIPTION
# Description
Typing error in install.rst (pip install woomF instead of pip install woom)
Minor correction

# Check list

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `CHANGES.rst`
- [ ] New modules are listed in `api.rst`
