### PR TITLE
Fix/slurm scheduler

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 """
 Pytest configuration and shared fixtures for woom tests
 """
+
 import sys
 from pathlib import Path
 from unittest.mock import Mock

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ Unit tests for woom.cli module
 
 Run: pytest test_cli.py -v
 """
+
 import argparse
 import os
 from unittest.mock import MagicMock, Mock, mock_open, patch

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -3,6 +3,7 @@
 """
 Tests for conf.py module
 """
+
 import pathlib
 
 import configobj

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -6,6 +6,7 @@ Unit tests for woom.context module
 Place this file at the root of your project (same level as woom/ directory)
 Run: pytest test_context.py -v
 """
+
 import os
 from unittest.mock import MagicMock, Mock
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -6,6 +6,7 @@ Unit tests for woom.env module
 Place this file at the root of your project (same level as woom/ directory)
 Run: pytest test_env.py -v
 """
+
 import os
 
 import pytest

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -6,6 +6,7 @@ Unit tests for woom.ext module
 Place this file at the root of your project (same level as woom/ directory)
 Run: pytest test_ext.py -v
 """
+
 import os
 import sys
 from unittest.mock import MagicMock, Mock, mock_open, patch

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -3,6 +3,7 @@
 """
 Tests for hosts.py module
 """
+
 from unittest.mock import patch
 
 import configobj
@@ -29,13 +30,11 @@ class TestHostManager:
         manager = whosts.HostManager()
 
         cfg_file = tmp_path / "custom_hosts.cfg"
-        cfg_file.write_text(
-            """
+        cfg_file.write_text("""
 [myhost]
 patterns = myhost*
 scheduler = slurm
-"""
-        )
+""")
 
         manager.load_config(str(cfg_file))
         assert "myhost" in manager.config

--- a/tests/test_iters.py
+++ b/tests/test_iters.py
@@ -3,6 +3,7 @@
 """
 Tests for iters.py module
 """
+
 import pytest
 
 from woom import WoomError

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -3,6 +3,7 @@
 """
 Tests for job.py module
 """
+
 import json
 from unittest.mock import MagicMock, Mock, patch
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -3,6 +3,7 @@
 """
 Tests for log.py module
 """
+
 import argparse
 import logging
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -3,6 +3,7 @@
 """
 Tests for render.py module
 """
+
 import os
 
 import pytest

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -6,6 +6,7 @@ Unit tests for woom.tasks module
 Place this file at the root of your project (same level as woom/ directory)
 Run: pytest test_tasks.py -v
 """
+
 import os
 from unittest.mock import MagicMock, Mock, patch
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,6 +6,7 @@ Unit tests for woom.util module
 Place this file at the root of your project (same level as woom/ directory)
 Run: pytest test_util.py -v
 """
+
 import json
 import os
 from unittest.mock import Mock, patch

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -40,7 +40,7 @@ class TestWoomDate:
 
     def test_init_with_round(self):
         """Test WoomDate with rounding"""
-        date = WoomDate('2020-01-01 12:34:56', round='H')
+        date = WoomDate('2020-01-01 12:34:56', round='h')
 
         assert date.hour == 13
         assert date.minute == 0

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -6,6 +6,7 @@ Unit tests for woom.workflow module
 Place this file at the root of your project (same level as woom/ directory)
 Run: pytest test_workflow.py -v
 """
+
 from unittest.mock import Mock, patch
 
 import pytest

--- a/woom/__init__.py
+++ b/woom/__init__.py
@@ -3,6 +3,7 @@
 """
 Light weight workflow manager for ocean models
 """
+
 import warnings
 
 try:

--- a/woom/conf.py
+++ b/woom/conf.py
@@ -3,6 +3,7 @@
 """
 Configurations related utilities based on the :mod:`configobj` system
 """
+
 import logging
 import pathlib
 import pprint

--- a/woom/context.py
+++ b/woom/context.py
@@ -3,6 +3,7 @@
 """
 Context for job script generation
 """
+
 import json
 import os
 from collections import UserDict

--- a/woom/env.py
+++ b/woom/env.py
@@ -3,6 +3,7 @@
 """
 Environment loading utilities
 """
+
 import os
 
 

--- a/woom/ext.py
+++ b/woom/ext.py
@@ -3,6 +3,7 @@
 """
 Woom extensions management
 """
+
 import importlib
 import os
 import sys

--- a/woom/hosts.py
+++ b/woom/hosts.py
@@ -3,6 +3,7 @@
 """
 Host specific configuration
 """
+
 import fnmatch
 import functools
 import os

--- a/woom/hosts.py
+++ b/woom/hosts.py
@@ -141,13 +141,18 @@ class Host:
     def get_queue(self, name):
         """Get a queue real name from its generic name
 
+        Accesses ``self._config`` directly instead of going through
+        ``self.config`` (which calls ``Section.dict()``).  After a
+        ``ConfigObj.merge()``, ``dict()`` may return spec defaults instead
+        of the user's values.
+
         See also
         --------
         queues
         """
-        if name in self.queues:
-            return self.queues[name]
-        return name
+        queues = self._config.get("queues", {})
+        val = queues.get(name) if hasattr(queues, "get") else None
+        return val if val else name
 
     def get_params(self):
         """Get a context dict for formatting task commandlines with jinja

--- a/woom/job.py
+++ b/woom/job.py
@@ -217,6 +217,9 @@ class Job:
     def __eq__(self, job):
         return str(self) == str(job)
 
+    def __hash__(self):
+        return hash(str(self))
+
     @property
     def files(self):
         """:class:`dict` of job files like script, status, out, err and json"""

--- a/woom/job.py
+++ b/woom/job.py
@@ -652,15 +652,16 @@ class ScheduledJob(Job):
         """
         args = self.manager._extra_status_args_(self.manager.get_command_args("status", jobid=self.jobid))
         logger.debug("Get status: " + " ".join(args))
-        res = subprocess.run(args, capture_output=True, check=True)
+        # check=False: squeue exits with code 1 when the job is no longer in the active
+        # queue (completed/failed). We must not raise — fall through to sacct instead.
+        res = subprocess.run(args, capture_output=True, check=False)
         logger.debug("Got status")
-        if res.returncode:
-            return JobStatus.UNKNOWN
 
-        # Parse active jobs
-        status_list = self.manager._parse_status_res_(res)
-        if status_list:
-            return status_list[0]["status"]
+        # Parse active jobs (only if the scheduler command succeeded)
+        if not res.returncode:
+            status_list = self.manager._parse_status_res_(res)
+            if status_list:
+                return status_list[0]["status"]
 
         # Fallback to history if job not in active queue
         if hasattr(self.manager, '_query_history_status_'):

--- a/woom/job.py
+++ b/woom/job.py
@@ -733,13 +733,13 @@ class _Scheduler_(BackgroundJobManager):
         """Submit the script and instantiate a :class:`Job` object"""
 
         # stdout and stderr
+        # Only set log paths if not already provided by the caller.
+        # Using setdefault() preserves absolute paths passed via opts; unconditionally
+        # overwriting them caused sbatch to resolve relative names against an unexpected
+        # CWD and create spurious log directories.
         rootname = os.path.splitext(os.path.basename(script))[0]
-        if stdout is None:
-            stdout = f"{rootname}.out"
-        if stderr is None:
-            stderr = f"{rootname}.err"
-        opts["log_out"] = stdout
-        opts["log_err"] = stderr
+        opts.setdefault("log_out", stdout or f"{rootname}.out")
+        opts.setdefault("log_err", stderr or f"{rootname}.err")
 
         # Submision
         job = super().submit(

--- a/woom/job.py
+++ b/woom/job.py
@@ -960,6 +960,22 @@ class SlurmJobManager(_Scheduler_):
         "DEADLINE": JobStatus.FAILED,
     }
 
+    # sacct returns full-word state names (different from squeue short codes).
+    history_status_names = {
+        "COMPLETED": JobStatus.SUCCESS,
+        "FAILED": JobStatus.FAILED,
+        "CANCELLED": JobStatus.KILLED,
+        "TIMEOUT": JobStatus.FAILED,
+        "OUT_OF_MEMORY": JobStatus.FAILED,
+        "NODE_FAIL": JobStatus.FAILED,
+        "BOOT_FAIL": JobStatus.FAILED,
+        "DEADLINE": JobStatus.FAILED,
+        "PREEMPTED": JobStatus.FAILED,
+        "RUNNING": JobStatus.RUNNING,
+        "PENDING": JobStatus.PENDING,
+        "SUSPENDED": JobStatus.PENDING,
+    }
+
     jobid_sep = ","
 
     def _extra_status_args_(self, args):

--- a/woom/job.py
+++ b/woom/job.py
@@ -718,6 +718,8 @@ class ScheduledJob(Job):
                 f.write(exit_code)
             self.set_status("TERMINATED" if graceful else "KILLED")
 
+    cancel = kill
+
 
 class _Scheduler_(BackgroundJobManager):
     job_class = ScheduledJob

--- a/woom/job.py
+++ b/woom/job.py
@@ -974,7 +974,7 @@ class SlurmJobManager(_Scheduler_):
 
     def _parse_status_res_(self, res):
         """JOBID PARTITION NAME USER ST TIME NODES NODELIST(REASON)"""
-        res = super()._parse_status_res_(self, res)
+        res = super()._parse_status_res_(res)
         out = []
         lines = res.splitlines()
         if lines:

--- a/woom/job.py
+++ b/woom/job.py
@@ -765,6 +765,8 @@ class _Scheduler_(BackgroundJobManager):
         if job.subproc.returncode:
             raise WoomJobError(f"Submission failed with error message: {stderr}")
         self._parse_submit_job_(job, stdout)  # update jobid
+        # Expose log file paths on the job object so callers can read them back.
+        job.files = {"out": opts.get("log_out", ""), "err": opts.get("log_err", "")}
         job.dump()
         return job
 

--- a/woom/job.py
+++ b/woom/job.py
@@ -765,8 +765,6 @@ class _Scheduler_(BackgroundJobManager):
         if job.subproc.returncode:
             raise WoomJobError(f"Submission failed with error message: {stderr}")
         self._parse_submit_job_(job, stdout)  # update jobid
-        # Expose log file paths on the job object so callers can read them back.
-        job.files = {"out": opts.get("log_out", ""), "err": opts.get("log_err", "")}
         job.dump()
         return job
 

--- a/woom/job.py
+++ b/woom/job.py
@@ -3,6 +3,7 @@
 """
 Job management utilities
 """
+
 import datetime
 import json
 import logging

--- a/woom/render.py
+++ b/woom/render.py
@@ -3,6 +3,7 @@
 """
 Jinja text rendering
 """
+
 import os
 import shlex
 

--- a/woom/tests/test_util.py
+++ b/woom/tests/test_util.py
@@ -3,6 +3,7 @@
 """
 Test the :mod:`woom.util` module
 """
+
 import woom.util as wutil
 
 

--- a/woom/util.py
+++ b/woom/util.py
@@ -3,6 +3,7 @@
 """
 Misc utilities
 """
+
 import collections
 import json
 import logging

--- a/woom/workflow.py
+++ b/woom/workflow.py
@@ -3,6 +3,7 @@
 """
 The workflow core
 """
+
 import functools
 import glob
 import logging


### PR DESCRIPTION
# Description
This branch fixes a series of bugs that collectively prevented woom from being used reliably as the job management layer for Slurm and PBS HPC pipelines. All issues were discovered while integrating woom into an external orchestrator (armoor) that relies on     
  SlurmJobManager for multi-wave HPC pipeline submission.                                                                          
                                                                                                                                     
  Fixes                                                                                                                              
                                                                                                                                   
  woom/job.py                                                                                                                        
   
  - _Scheduler_.submit() — log paths (log_out, log_err) provided by the caller via opts were unconditionally overwritten with a relative basename (job.out), silently discarding absolute paths and causing sbatch to create log files in unexpected directories.
  Fixed by using opts.setdefault().                                                                                                  
  - ScheduledJob.query_status() — check=True raised CalledProcessError when squeue exits with code 1 (job no longer in active queue), preventing the fallback to sacct. Fixed by using check=False and only parsing output when the command succeeded.                  
  - SlurmJobManager._parse_status_res_() — super()._parse_status_res_(self, res) passed self twice, causing a TypeError at every status query. Fixed to super()._parse_status_res_(res).                                                                            
  - SlurmJobManager — _query_history_status_() referenced self.history_status_names which was never defined, causing an            
  AttributeError when parsing sacct output. Added the missing dict mapping full-word sacct states to JobStatus values.               
  - ScheduledJob — no cancel() method existed; callers expecting job.cancel() got an AttributeError. Added cancel = kill alias.    
  - Job — defining __eq__ without __hash__ makes instances unhashable in Python 3, preventing their use as dictionary keys. Added   __hash__ consistent with __eq__ (both based on str(self)).                                                                         
                                                                                                                                     
  woom/hosts.py                                                                                                                      
                                                                                                                                   
  - Host.get_queue() — went through self.config → Section.dict(), which returns spec defaults instead of user values after a configobj.merge(). Fixed by accessing self._config directly.

# Check list

- [ ] Closes #29
- [ ] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `CHANGES.rst`
- [ ] New modules are listed in `api.rst`
