### PR TITLE
Fix/render artifact run dir

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,9 @@ Deprecations
 
 Bug fixes
 ---------
+* Fix relative artifact paths being joined with an un-rendered ``run_dir`` Jinja
+  template, causing the path to be resolved in the calling task's context instead
+  of the artifact's own task context.
 * Fix ``Workflow.get_artifacts`` iterating over characters of a path string for
   single-path artifacts instead of treating the string as one path.
 * Fix ``Host.get_env`` that was ignoring ``raw_text`` and ``uv_venv`` configuration options.

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -306,11 +306,13 @@ class TestTask:
             }
         )
         task = Task(config, mock_host)
-        task.set_context({
-            'task': task,
-            'scratch_dir': '/scratch/user',
-            'task_path': 'prolog/compile_ibc',
-        })
+        task.set_context(
+            {
+                'task': task,
+                'scratch_dir': '/scratch/user',
+                'task_path': 'prolog/compile_ibc',
+            }
+        )
 
         artifacts = task.render_artifacts()
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -284,6 +284,38 @@ class TestTask:
         assert 'output' in artifacts
         assert artifacts['output'] == ['/tmp/output.txt']
 
+    def test_render_artifacts_relative_with_jinja_run_dir(self, mock_host):
+        """Relative artifact path must be resolved against the task's own run_dir,
+        even when run_dir is itself a Jinja template."""
+        config = ConfigObj(
+            {
+                'content': {
+                    'commandline': '',
+                    'run_dir': '{{ scratch_dir }}/woom/{{ task_path }}',
+                    'env': None,
+                },
+                'artifacts': {
+                    'extract_exe': {
+                        'path': 'extract_exe',
+                        'check': True,
+                        'callable': False,
+                        'kwargs': {},
+                    }
+                },
+                'submit': {},
+            }
+        )
+        task = Task(config, mock_host)
+        task.set_context({
+            'task': task,
+            'scratch_dir': '/scratch/user',
+            'task_path': 'prolog/compile_ibc',
+        })
+
+        artifacts = task.render_artifacts()
+
+        assert artifacts['extract_exe'] == '/scratch/user/woom/prolog/compile_ibc/extract_exe'
+
     def test_context_setter(self, mock_host):
         """Test context setter"""
         config = ConfigObj(

--- a/woom/tasks.py
+++ b/woom/tasks.py
@@ -420,8 +420,9 @@ class Task:
             for path_ in paths:
                 rendered = wrender.render(path_.strip(), self.context)
                 if not os.path.isabs(path_):
-                    if self.run_dir:
-                        rendered = os.path.join(self.run_dir, rendered)
+                    run_dir = wrender.render(self.run_dir, self.context)
+                    if run_dir:
+                        rendered = os.path.join(run_dir, rendered)
                     else:
                         raise TaskError(
                             f"Rendered artifact '{name}' of task '{self.name}' is not absolute "


### PR DESCRIPTION
# Description

Fix a bug where `render_artifacts()` joined a relative artifact path with the un-rendered Jinja template string from `run_dir` (default: `{{ scratch_dir }}/woom/{{ task_path }}`), causing the path to be resolved in the *calling* task's context instead of the artifact's own task context.
This produced wrong cycle and task names in artifact paths returned by `get_task_artifact_paths()`.

# Check list

- [ ] Closes #xxxx
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `CHANGES.rst`
- [ ] New modules are listed in `api.rst`
