### PR TITLE
Fix/slurm remove hardcoded exclusive

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,9 @@ Deprecations
 
 Bug fixes
 ---------
+* SLURM: remove the hardcoded ``--exclusive`` flag from ``sbatch`` submissions;
+  this option depends on the partition and should be set by the user in the
+  ``[[submit]]`` section of their task when needed.
 * Fix relative artifact paths being joined with an un-rendered ``run_dir`` Jinja
   template, causing the path to be resolved in the calling task's context instead
   of the artifact's own task context.

--- a/woom/job.py
+++ b/woom/job.py
@@ -965,7 +965,7 @@ class SlurmJobManager(_Scheduler_):
         "submit": {
             "command": "sbatch",
             "options": {
-                "name": "--exclusive -J {}",
+                "name": "-J {}",
                 "queue": "-p {}",
                 "nnodes": "-N {}",
                 "ncpus": "-c {}",


### PR DESCRIPTION
# Fix: remove hardcoded `--exclusive` from SLURM sbatch submissions

Remove the hardcoded `--exclusive` flag prepended to the `-J` option in
`SlurmJobManager`. This option depends on the partition and should be set
by the user when needed.

Users who relied on the implicit `--exclusive` behaviour must now set it
explicitly in the `[[submit]]` section of their task:

```ini
[[submit]]
extra = --exclusive
```

# Check list

- [ ] Closes #xxxx
- [ ] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `CHANGES.rst`
- [ ] New modules are listed in `api.rst`