### PR TITLE
feat(cycles): add horizon option for forecast-style date cycles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ New features
 * Add the capability to fill templates with a decated section in tasks and with the ``woom fill`` command [:pull:`22`].
 * User paramaters specified in the workflow configuration can now contain sub-sections [:pull:`22`].
 * Switch CI and pre-commit to ruff [:pull:`34`]
+* Add a ``horizon`` option to the ``[cycles]`` section: when ``as_intervals=False``, sets ``end_date = begin_date + horizon`` on each :class:`~woom.iters.Cycle`, making ``cycle_end_date`` and ``cycle_duration`` available in templates [:pull:`38`].
 
 Breaking changes
 ----------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Constraints
+
+Never commit without explicit permission from the user.
+Propose short commit messages without mentioning Claude.
+
+## Commands
+
+```bash
+# Install for development
+pip install -e .[dev]
+
+# Run all tests
+pytest -v
+
+# Run a single test
+pytest tests/test_iters.py::TestCycle::test_cycle_single_date -v
+
+# Lint
+ruff check woom tests
+
+# Format check (CI)
+ruff format --check woom tests
+
+# Auto-format
+ruff format woom tests
+
+# Build docs
+cd docs && make html
+```
+
+## Architecture
+
+woom is a workflow manager for ocean models. Users write three config files (`workflow.cfg`, `tasks.cfg`, `hosts.cfg`) and run `woom run` to submit batched job sequences to an HPC scheduler (Slurm, PBS Pro) or locally.
+
+### Config system
+
+All config files are INI-style, loaded and validated by `configobj` via `woom/conf.py`. Each config type has a matching `.ini` spec file (`workflow.ini`, `tasks.ini`, `hosts.ini`) inside `woom/`. The spec files declare types like `datetime`, `timedelta`, `path`, and `pages` which are custom validator functions registered in `conf.py:VALIDATOR_FUNCTIONS`.
+
+### Core data flow
+
+1. `Workflow.__init__` loads `workflow.cfg`, validates it, then calls `iters.gen_cycles()` and `iters.gen_ensemble()` to produce the `Cycle` and `Member` lists.
+2. When running, the workflow loops over stages (`prolog` → `cycles` → `epilog`), then over `Cycle` objects and `Member` objects.
+3. For each task/cycle/member combination, a `Context` dict (`context.py`) is built by merging: workflow config, host params, cycle params (`Cycle.get_params()`), member params, task params, and user `[params]` from `workflow.cfg`.
+4. The context is passed to Jinja2 to render batch scripts and task template files.
+5. The rendered script is submitted via a job manager (`job.py`: `SlurmJobManager`, `PbsproJobManager`, or `LocalJobManager`).
+
+### Key classes
+
+- `Cycle` (`iters.py`): Represents either a single date or a time interval. Has `begin_date`, `end_date`, `duration`, `is_interval`, `is_first`, `is_last`, `prev`, `next`. `end_date` is `None` when `as_intervals=False`.
+- `gen_cycles()` (`iters.py`): Produces the list of `Cycle` objects from `workflow.cfg [cycles]` parameters.
+- `Member` (`iters.py`): Represents an ensemble member with user-defined properties via `[[iters]]` subsection.
+- `Workflow` (`workflow.py`): Central orchestrator. Holds cycles, members, task tree, and the context cache (`@functools.lru_cache` on `get_context()`).
+- `Context` (`context.py`): A `UserDict` passed to Jinja2. Built fresh for each task/cycle/member. Includes all cycle params prefixed `cycle_*`, member params, task params, path helpers, etc.
+- `TaskTree` / `TaskManager` (`tasks.py`): Parses `tasks.cfg` and the `[stages]` section of `workflow.cfg`. Returns task sequences and groups.
+
+### Academic examples
+
+Self-contained runnable examples live in `examples/academic/<name>/`. Each example is a directory containing at minimum `README.rst` and `workflow.cfg`; `tasks.cfg` and `hosts.cfg` are included when needed. A custom `example.rst` Jinja template can be added to override or extend the generated documentation page for that example.
+
+During doc generation (`cd docs && make html`), the `docs/ext/genexamples.py` Sphinx extension scans `examples/academic/` and `examples/realistic/`, renders an RST page for each directory that has a `README.rst`, and writes it to `docs/examples/<section>/<name>.rst`. The default template (`docs/_templates/genexamples/example.rst`) runs `woom show overview`, `woom run --dry-run`, `woom run`, `woom show status`, and `woom show run_dirs` live via `sphinxcontrib-programoutput`, so examples must be fully runnable without a scheduler.
+
+Reference an example from documentation with `:ref:\`examples.academic.<name>\``.
+
+### Extensions
+
+Workflows can extend woom by placing files in their `ext/` subdirectory:
+- `ext/jinja_filters.py`: custom Jinja2 filters
+- `ext/validator_functions.py`: additional configobj validator types
+- `ext/cfgspecs/`: custom `.ini` specs merged with built-in ones
+
+These are loaded by `ext.py:load_extensions()` at workflow startup.
+
+### Cycle modes
+
+The `[cycles]` section of `workflow.cfg` drives `gen_cycles()`:
+- `as_intervals=True` (default): N dates → N-1 interval `Cycle` objects, each with `begin_date` and `end_date`.
+- `as_intervals=False`: N dates → N point-in-time `Cycle` objects, `end_date=None`.

--- a/docs/indepth_workflow.rst
+++ b/docs/indepth_workflow.rst
@@ -203,68 +203,7 @@ changing the directory structure, which remains anchored to ``begin_date`` only.
 ``horizon`` accepts any pandas timedelta string (``5D``, ``12h``, ``1W``, …).
 It is ignored when ``as_intervals = True`` (those cycles already have explicit end dates).
 
-**Academic example: daily ocean weather forecasts**
-
-A common NWP use-case: run the model once per day, each time producing a 5-day forecast.
-Every cycle starts from a different initialization date but covers the same forecast length.
-
-.. code-block:: ini
-
-    [app]
-    name = nemo
-    conf = north_atlantic
-    exp  = forecast_2020
-
-    [cycles]
-    begin_date   = 2020-01-01
-    end_date     = 2020-01-07
-    freq         = 1D
-    as_intervals = False   # one cycle per initialization date
-    horizon      = 5D      # each run produces a 5-day forecast
-    indep        = True    # forecasts are independent — run in parallel
-
-    [stages]
-        [[cycles]]
-        forecast = run_ocean_model, compute_diagnostics
-
-This generates 7 cycles (one per day). Their attributes are:
-
-+------------+------------------+------------------+-----------+
-| begin_date | end_date         | duration         | is_interval |
-+============+==================+==================+=============+
-| 2020-01-01 | 2020-01-06       | 5 days           | False     |
-+------------+------------------+------------------+-----------+
-| 2020-01-02 | 2020-01-07       | 5 days           | False     |
-+------------+------------------+------------------+-----------+
-| …          | …                | …                | …         |
-+------------+------------------+------------------+-----------+
-| 2020-01-07 | 2020-01-12       | 5 days           | False     |
-+------------+------------------+------------------+-----------+
-
-In the task template you can write:
-
-.. code-block:: jinja
-
-    # Initialization date (cycle directory anchor)
-    init_date = {{ cycle_begin_date }}
-
-    # Forecast end date  (= init_date + 5 days)
-    end_date  = {{ cycle_end_date }}
-
-    # Forecast length (pandas Timedelta, e.g. "5 days 00:00:00")
-    duration  = {{ cycle_duration }}
-
-Submission directories are still named after ``cycle_begin_date`` only, so the
-jobs tree is the same as it would be without ``horizon``:
-
-.. code-block:: text
-
-    jobs/nemo/north_atlantic/forecast_2020/
-    ├── 2020-01-01T00:00:00+00:00/
-    │   ├── run_ocean_model/
-    │   └── compute_diagnostics/
-    ├── 2020-01-02T00:00:00+00:00/
-    └── …
+See :ref:`examples.academic.horizon` for a worked example.
 
 Ensemble Configuration
 ======================

--- a/docs/indepth_workflow.rst
+++ b/docs/indepth_workflow.rst
@@ -191,6 +191,81 @@ No Cycles
 
 Creates a single "cycle" with fixed date. Tasks in the cycles stage run once.
 
+Forecast Cycles (``horizon``)
+-----------------------------
+
+The ``horizon`` option adds a forecast window to date-based cycles (``as_intervals = False``).
+Without it, each cycle has only a ``begin_date`` and ``end_date`` is ``None``.
+With ``horizon``, each cycle's ``end_date`` is set to ``begin_date + horizon``, making
+``{{ cycle_end_date }}`` and ``{{ cycle_duration }}`` available in templates — without
+changing the directory structure, which remains anchored to ``begin_date`` only.
+
+``horizon`` accepts any pandas timedelta string (``5D``, ``12h``, ``1W``, …).
+It is ignored when ``as_intervals = True`` (those cycles already have explicit end dates).
+
+**Academic example: daily ocean weather forecasts**
+
+A common NWP use-case: run the model once per day, each time producing a 5-day forecast.
+Every cycle starts from a different initialization date but covers the same forecast length.
+
+.. code-block:: ini
+
+    [app]
+    name = nemo
+    conf = north_atlantic
+    exp  = forecast_2020
+
+    [cycles]
+    begin_date   = 2020-01-01
+    end_date     = 2020-01-07
+    freq         = 1D
+    as_intervals = False   # one cycle per initialization date
+    horizon      = 5D      # each run produces a 5-day forecast
+    indep        = True    # forecasts are independent — run in parallel
+
+    [stages]
+        [[cycles]]
+        forecast = run_ocean_model, compute_diagnostics
+
+This generates 7 cycles (one per day). Their attributes are:
+
++------------+------------------+------------------+-----------+
+| begin_date | end_date         | duration         | is_interval |
++============+==================+==================+=============+
+| 2020-01-01 | 2020-01-06       | 5 days           | False     |
++------------+------------------+------------------+-----------+
+| 2020-01-02 | 2020-01-07       | 5 days           | False     |
++------------+------------------+------------------+-----------+
+| …          | …                | …                | …         |
++------------+------------------+------------------+-----------+
+| 2020-01-07 | 2020-01-12       | 5 days           | False     |
++------------+------------------+------------------+-----------+
+
+In the task template you can write:
+
+.. code-block:: jinja
+
+    # Initialization date (cycle directory anchor)
+    init_date = {{ cycle_begin_date }}
+
+    # Forecast end date  (= init_date + 5 days)
+    end_date  = {{ cycle_end_date }}
+
+    # Forecast length (pandas Timedelta, e.g. "5 days 00:00:00")
+    duration  = {{ cycle_duration }}
+
+Submission directories are still named after ``cycle_begin_date`` only, so the
+jobs tree is the same as it would be without ``horizon``:
+
+.. code-block:: text
+
+    jobs/nemo/north_atlantic/forecast_2020/
+    ├── 2020-01-01T00:00:00+00:00/
+    │   ├── run_ocean_model/
+    │   └── compute_diagnostics/
+    ├── 2020-01-02T00:00:00+00:00/
+    └── …
+
 Ensemble Configuration
 ======================
 

--- a/examples/academic/horizon/README.rst
+++ b/examples/academic/horizon/README.rst
@@ -1,0 +1,19 @@
+Forecast cycles with horizon
+============================
+
+About
+-----
+
+This example demonstrates the ``horizon`` option for date-based cycles (``as_intervals = False``).
+
+Three initialization dates are defined (2020-01-01, 2020-01-02, 2020-01-03), each producing
+a 5-day forecast. The ``horizon = 5D`` setting computes ``end_date = begin_date + 5 days``
+for every cycle, making :attr:`~woom.iters.Cycle.end_date` and
+:attr:`~woom.iters.Cycle.duration` available in templates via ``cycle_end_date`` and
+``cycle_duration`` — without making :attr:`~woom.iters.Cycle.is_interval` True.
+
+**forecast** task:
+
+- Prints the initialization date (``cycle_begin_date``) and the forecast end date (``cycle_end_date``)
+- Illustrates that a single-date cycle can carry a forecast window alongside its anchor date
+- Cycles run independently (``indep = True``) since forecasts do not depend on each other

--- a/examples/academic/horizon/tasks.cfg
+++ b/examples/academic/horizon/tasks.cfg
@@ -1,0 +1,3 @@
+[forecast]
+    [[content]]
+    commandline=echo "Init: {{ cycle_begin_date.strftime('%Y-%m-%d') }}  End: {{ cycle_end_date.strftime('%Y-%m-%d') }}  ({{ cycle_duration.days }}d horizon)"

--- a/examples/academic/horizon/workflow.cfg
+++ b/examples/academic/horizon/workflow.cfg
@@ -1,0 +1,14 @@
+[app]
+name=academic_horizon
+
+[cycles]
+begin_date=2020-01-01
+end_date=2020-01-03
+freq=1D
+as_intervals=False
+horizon=5D
+indep=True
+
+[stages]
+    [[cycles]]
+    seq0=forecast

--- a/tests/test_iters.py
+++ b/tests/test_iters.py
@@ -112,6 +112,44 @@ class TestCycle:
         cycle = witers.Cycle("2020-01-01", "2020-01-10")
         assert cycle == "2020-01-01T00:00:00+00:00-2020-01-10T00:00:00+00:00"
 
+    def test_cycle_with_horizon(self):
+        """Horizon sets end_date and duration without making is_interval True"""
+        cycle = witers.Cycle("2020-01-01", horizon="5D")
+        assert not cycle.is_interval
+        assert cycle.horizon is not None
+        assert cycle.end_date is not None
+        assert cycle.end_date.day == 6  # 2020-01-01 + 5 days
+        assert cycle.duration.days == 5
+
+    def test_cycle_with_horizon_params(self):
+        """Horizon cycle exports cycle_date, cycle_end_date and cycle_duration"""
+        cycle = witers.Cycle("2020-01-01", horizon="5D")
+        params = cycle.get_params()
+        assert "cycle_date" in params
+        assert "cycle_end_date" in params
+        assert "cycle_duration" in params
+        assert params["cycle_duration"].days == 5
+
+    def test_cycle_with_horizon_token_unchanged(self):
+        """Token stays anchored to begin_date only for directory naming"""
+        cycle = witers.Cycle("2020-01-01", horizon="5D")
+        assert "2020-01-01" in cycle.token
+        assert "2020-01-06" not in cycle.token
+
+    def test_cycle_with_horizon_label(self):
+        """Label shows the begin date and horizon offset"""
+        cycle = witers.Cycle("2020-01-01", horizon="5D")
+        assert "2020-01-01" in cycle.label
+        assert "5" in cycle.label  # duration shown
+
+    def test_cycle_no_horizon_no_end_date(self):
+        """Without horizon, single-date cycle has no end_date params"""
+        cycle = witers.Cycle("2020-01-01")
+        params = cycle.get_params()
+        assert "cycle_date" in params
+        assert "cycle_end_date" not in params
+        assert "cycle_duration" not in params
+
 
 class TestGenCycles:
     """Test cycle generation"""
@@ -164,6 +202,31 @@ class TestGenCycles:
     def test_gen_cycles_no_begin_date(self):
         with pytest.raises(WoomError):
             witers.gen_cycles(None)
+
+    def test_gen_cycles_with_horizon(self):
+        """Horizon propagates to each date-based cycle"""
+        import pandas as pd
+
+        cycles = witers.gen_cycles("2020-01-01", "2020-01-03", freq="1D", as_intervals=False, horizon="5D")
+        assert len(cycles) == 3
+        assert all(not c.is_interval for c in cycles)
+        assert all(c.horizon == pd.Timedelta("5D") for c in cycles)
+        assert all(c.end_date is not None for c in cycles)
+        for cycle in cycles:
+            assert cycle.end_date == cycle.begin_date + pd.Timedelta("5D")
+
+    def test_gen_cycles_horizon_ignored_for_intervals(self):
+        """Horizon is ignored when as_intervals=True"""
+        cycles = witers.gen_cycles("2020-01-01", "2020-01-05", freq="1D", as_intervals=True, horizon="5D")
+        assert all(c.is_interval for c in cycles)
+        assert all(c.horizon is None for c in cycles)
+
+    def test_gen_cycles_single_date_with_horizon(self):
+        """Single date gen_cycles also gets the horizon"""
+        cycles = witers.gen_cycles("2020-01-01", horizon="3D")
+        assert len(cycles) == 1
+        assert cycles[0].end_date is not None
+        assert cycles[0].duration.days == 3
 
 
 class TestMember:

--- a/woom/iters.py
+++ b/woom/iters.py
@@ -28,6 +28,10 @@ class Cycle:
         The start date of the cycle
     end_date : date-like, optional
         The end date of the cycle. If None, the cycle represents a single point in time.
+    horizon : timedelta-like, optional
+        Forecast horizon. When set on a single-date cycle (``end_date=None``), sets
+        ``end_date = begin_date + horizon`` so that ``cycle_end_date`` and
+        ``cycle_duration`` are available in templates without making ``is_interval`` True.
 
     Notes
     -----
@@ -61,7 +65,7 @@ class Cycle:
     True
     """
 
-    def __init__(self, begin_date, end_date=None):
+    def __init__(self, begin_date, end_date=None, horizon=None):
         #: Begin date (:class:`~woom.util.WoomDate`)
         self.begin_date = wutil.WoomDate(begin_date)
         #: Same as :attr:`begin_date`
@@ -72,11 +76,18 @@ class Cycle:
         self.is_first = False
         #: Whether it is the last cycle  (:class:`bool`)
         self.is_last = False
+        #: Forecast horizon (:class:`~pandas.Timedelta` or None)
+        self.horizon = pd.to_timedelta(horizon) if horizon is not None else None
         if not self.is_interval:
-            self.end_date = self.duration = None
+            if self.horizon is not None:
+                #: End date (:class:`~woom.util.WoomDate` or None)
+                self.end_date = wutil.WoomDate(self.begin_date + self.horizon)
+                #: Interval duration (:class:`~pandas.Timedelta` or None)
+                self.duration = self.horizon
+            else:
+                self.end_date = self.duration = None
         else:
             #: End date (:class:`~woom.util.WoomDate` or None)
-            #: defaults to None
             self.end_date = wutil.WoomDate(end_date)
             #: Interval duration (:class:`~pandas.Timedelta` or None)
             self.duration = self.end_date - self.begin_date
@@ -84,11 +95,14 @@ class Cycle:
         # Label
         if self.is_interval:
             self.label = f"{self.begin_date.isoformat()} -> {self.end_date.isoformat()} ({self.duration})"
+        elif self.horizon is not None:
+            #: String used for for printing and based on the ISO 8601 format (:class:`str`)
+            self.label = f"{self.begin_date.isoformat()} +{self.duration}"
         else:
             #: String used for for printing and based on the ISO 8601 format (:class:`str`)
             self.label = self.begin_date.isoformat()
 
-        # Token
+        # Token — always anchored to begin_date only (drives directory names)
         if self.is_interval:
             self.token = f"{self.begin_date.isoformat()}-{self.end_date.isoformat()}"
         else:
@@ -160,15 +174,15 @@ class Cycle:
             "cycle_label" + suffix: self.label,
             "cycle_token" + suffix: self.token,
         }
-        if self.is_interval:
+        if not self.is_interval:
+            params["cycle_date" + suffix] = params["cycle_begin_date" + suffix]
+        if self.end_date is not None:
             params.update(
                 {
                     "cycle_end_date" + suffix: self.end_date,
                     "cycle_duration" + suffix: self.duration,
                 }
             )
-        else:
-            params["cycle_date" + suffix] = params["cycle_begin_date" + suffix]
         params["cycle_is_first" + suffix] = self.is_first
         params["cycle_is_last" + suffix] = self.is_last
         params["cycle_next" + suffix] = self.next
@@ -181,7 +195,9 @@ class Cycle:
         return wutil.dict_to_env_vars(params)
 
 
-def gen_cycles(begin_date, end_date=None, freq=None, ncycles=None, round=None, as_intervals=True):
+def gen_cycles(
+    begin_date, end_date=None, freq=None, ncycles=None, round=None, as_intervals=True, horizon=None
+):
     """Get a list of :class:`Cycle` instances given time specifications
 
     The first cycle has the :attr:`Cycle.is_first` attribute set to True.
@@ -207,6 +223,12 @@ def gen_cycles(begin_date, end_date=None, freq=None, ncycles=None, round=None, a
         ``[Cycle(date0, date1), Cycle(date1, date2)]``,
         else
         ``[Cycle(date0), Cycle(date1), Cycle(date2)]``.
+    horizon: timedelta-like, None
+        Forecast horizon applied when ``as_intervals=False``.
+        Each cycle's :attr:`~Cycle.end_date` is set to ``begin_date + horizon``
+        and :attr:`~Cycle.duration` to ``horizon``, making ``cycle_end_date``
+        and ``cycle_duration`` available in templates.
+        Ignored when ``as_intervals=True``.
     """
     if begin_date is None:
         raise WoomError("begin_date must be None to generate cycles")
@@ -242,7 +264,7 @@ def gen_cycles(begin_date, end_date=None, freq=None, ncycles=None, round=None, a
 
     # Single date
     if len(rundates) == 1:
-        return [Cycle(rundates[0])]
+        return [Cycle(rundates[0], horizon=horizon)]
 
     # A list of time intervals
     if as_intervals:
@@ -251,7 +273,7 @@ def gen_cycles(begin_date, end_date=None, freq=None, ncycles=None, round=None, a
             date1 = rundates[i + 1]
             cycles.append(Cycle(date0, date1))
     else:
-        cycles = [Cycle(date) for date in rundates]
+        cycles = [Cycle(date, horizon=horizon) for date in rundates]
 
     if not cycles:
         raise WoomError(

--- a/woom/workflow.ini
+++ b/woom/workflow.ini
@@ -11,6 +11,7 @@ freq=string(default=None) # splitting frequency for cycles
 ncycles=integer(min=0,default=0)  # number of cycles
 indep=boolean(default=False) # are cycles indepedant from one another?
 as_intervals=boolean(default=True) # interpret cycles as a series of ncycles intervals or ncycles+1 dates?
+horizon=timedelta(default=None) # forecast horizon: when as_intervals=False, sets end_date = begin_date + horizon
 
 [ensemble]
 size=integer(min=0,default=None) # size of the ensemble


### PR DESCRIPTION
# Description

When as_intervals=False, setting horizon in the [cycles] section computes end_date = begin_date + horizon on each Cycle, exposing cycle_end_date and cycle_duration in templates without altering the directory structure.


# Check list

- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `CHANGES.rst`
