### PR TITLE
fix(run): preserve job dependencies when tasks are skipped

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,10 @@ Deprecations
 
 Bug fixes
 ---------
+* Fix job dependencies being lost between cycles when tasks are skipped via
+  ``--skip`` or ``[stages] skip``: ``task_depend`` and ``sequence_depend`` are
+  now preserved across skipped tasks instead of being reset to an empty list
+  [:pull:`39`].
 * SLURM: remove the hardcoded ``--exclusive`` flag from ``sbatch`` submissions;
   this option depends on the partition and should be set by the user in the
   ``[[submit]]`` section of their task when needed.

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -815,12 +815,14 @@ class TestWorkflowSkip:
             call_index[0] += 1
             return idx == 1
 
-        with patch.object(workflow, 'is_task_skipped', side_effect=is_skipped), \
-             patch.object(workflow, 'get_task_status', return_value=JobStatus['NOTSUBMITTED']), \
-             patch.object(workflow, 'clean_task'), \
-             patch.object(workflow, 'submit_task_fake', side_effect=fake_submit), \
-             patch.object(workflow, 'set_context', return_value=MagicMock()), \
-             patch.object(workflow, 'terminate_blocking_jobs'):
+        with (
+            patch.object(workflow, 'is_task_skipped', side_effect=is_skipped),
+            patch.object(workflow, 'get_task_status', return_value=JobStatus['NOTSUBMITTED']),
+            patch.object(workflow, 'clean_task'),
+            patch.object(workflow, 'submit_task_fake', side_effect=fake_submit),
+            patch.object(workflow, 'set_context', return_value=MagicMock()),
+            patch.object(workflow, 'terminate_blocking_jobs'),
+        ):
             workflow.run(dry=True)
 
         assert len(submitted_depends) == 2, "Cycles 1 and 3 should each submit one job"
@@ -867,6 +869,7 @@ class TestWorkflowSkip:
                 job.__str__ = Mock(return_value=str(job_counter[0]))
                 submitted_depends[task_name] = list(depend)
                 return job
+
             return _submit
 
         # is_task_skipped: True only for taskA
@@ -886,12 +889,14 @@ class TestWorkflowSkip:
             submitted_depends[name] = list(depend)
             return job
 
-        with patch.object(workflow, 'is_task_skipped', side_effect=is_skipped), \
-             patch.object(workflow, 'get_task_status', return_value=JobStatus['NOTSUBMITTED']), \
-             patch.object(workflow, 'clean_task'), \
-             patch.object(workflow, 'submit_task_fake', side_effect=fake_submit_ordered), \
-             patch.object(workflow, 'set_context', return_value=MagicMock()), \
-             patch.object(workflow, 'terminate_blocking_jobs'):
+        with (
+            patch.object(workflow, 'is_task_skipped', side_effect=is_skipped),
+            patch.object(workflow, 'get_task_status', return_value=JobStatus['NOTSUBMITTED']),
+            patch.object(workflow, 'clean_task'),
+            patch.object(workflow, 'submit_task_fake', side_effect=fake_submit_ordered),
+            patch.object(workflow, 'set_context', return_value=MagicMock()),
+            patch.object(workflow, 'terminate_blocking_jobs'),
+        ):
             workflow.run(dry=True)
 
         assert 'taskPre' in submitted_depends

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -778,8 +778,10 @@ class TestWorkflowSkip:
         assert status == JobStatus.SKIPPED
 
     def test_skip_preserves_inter_cycle_dependencies(self, minimal_config, mock_taskmanager, tmp_path):
-        """When a cycle's tasks are all skipped, subsequent cycles depend on the last non-skipped cycle's jobs"""
+        """When a cycle's tasks are all skipped, subsequent cycles depend on
+        the last non-skipped cycle's jobs"""
         from unittest.mock import MagicMock
+
         from woom.job import JobStatus
 
         minimal_config['cycles']['end_date'] = '2020-01-04'
@@ -832,6 +834,7 @@ class TestWorkflowSkip:
     def test_skip_preserves_intragroup_task_depend(self, minimal_config, mock_taskmanager, tmp_path):
         """When task A is skipped inside a group [A, B], task B still depends on the previous sequence"""
         from unittest.mock import MagicMock
+
         from woom.job import JobStatus
 
         # seq1 runs taskPre, seq2 runs group [taskA (skipped), taskB]

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -906,3 +906,90 @@ class TestWorkflowSkip:
         assert 'taskB' in submitted_depends
         assert submitted_depends['taskPre'] == [], "taskPre has no prior dependency"
         assert len(submitted_depends['taskB']) == 1, "taskB must depend on taskPre's job (not empty)"
+
+
+class TestWorkflowForce:
+    """Test force/no-force behaviour on second run"""
+
+    def test_successful_task_not_resubmitted_without_force(
+        self, minimal_config, mock_taskmanager, tmp_path
+    ):
+        """A task with SUCCESS status must not be re-submitted when force=False (default)"""
+        from unittest.mock import MagicMock
+
+        from woom.job import JobStatus
+
+        minimal_config['stages']['prolog'] = {'seq': ['taskA']}
+        minimal_config.filename = str(tmp_path / 'workflow.cfg')
+
+        mock_task = Mock()
+        mock_task.is_skipped = False
+        mock_task.is_blocking = True
+        mock_task.name = 'taskA'
+        mock_taskmanager.get_task.return_value = mock_task
+        mock_taskmanager.host.get_jobmanager.return_value.with_scheduler = None
+
+        workflow = Workflow(minimal_config, mock_taskmanager)
+
+        submit_calls = []
+
+        def fake_submit(depend, blocking):
+            job = Mock()
+            job.__str__ = Mock(return_value='1')
+            submit_calls.append('taskA')
+            return job
+
+        with (
+            patch.object(workflow, 'is_task_skipped', return_value=False),
+            patch.object(workflow, 'get_task_status', return_value=JobStatus.SUCCESS),
+            patch.object(workflow, 'clean_task'),
+            patch.object(workflow, 'submit_task_fake', side_effect=fake_submit),
+            patch.object(workflow, 'set_context', return_value=MagicMock()),
+            patch.object(workflow, 'terminate_blocking_jobs'),
+        ):
+            workflow.run(dry=True, force=False)
+
+        assert submit_calls == [], "Task already in SUCCESS must not be re-submitted when force=False"
+
+    def test_successful_task_resubmitted_with_force(
+        self, minimal_config, mock_taskmanager, tmp_path
+    ):
+        """A task with SUCCESS status must be re-submitted when force=True"""
+        from unittest.mock import MagicMock
+
+        from woom.job import JobStatus
+
+        minimal_config['stages']['prolog'] = {'seq': ['taskA']}
+        minimal_config.filename = str(tmp_path / 'workflow.cfg')
+
+        mock_task = Mock()
+        mock_task.is_skipped = False
+        mock_task.is_blocking = True
+        mock_task.name = 'taskA'
+        mock_taskmanager.get_task.return_value = mock_task
+        mock_taskmanager.host.get_jobmanager.return_value.with_scheduler = None
+
+        workflow = Workflow(minimal_config, mock_taskmanager)
+
+        submit_calls = []
+
+        def fake_submit(depend, blocking):
+            job = Mock()
+            job.__str__ = Mock(return_value='1')
+            submit_calls.append('taskA')
+            return job
+
+        success_status = JobStatus.SUCCESS
+        success_status.jobid = ''
+
+        with (
+            patch.object(workflow, 'is_task_skipped', return_value=False),
+            patch.object(workflow, 'get_task_status', return_value=success_status),
+            patch.object(workflow, 'clean_task'),
+            patch.object(workflow, 'submit_task_fake', side_effect=fake_submit),
+            patch.object(workflow, 'set_context', return_value=MagicMock()),
+            patch.object(workflow, 'terminate_blocking_jobs'),
+        ):
+            workflow.run(dry=True, force=True)
+
+        assert submit_calls == ['taskA'], "Task must be re-submitted when force=True"

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -776,3 +776,125 @@ class TestWorkflowSkip:
         status = workflow.get_task_status('task1')
 
         assert status == JobStatus.SKIPPED
+
+    def test_skip_preserves_inter_cycle_dependencies(self, minimal_config, mock_taskmanager, tmp_path):
+        """When a cycle's tasks are all skipped, subsequent cycles depend on the last non-skipped cycle's jobs"""
+        from unittest.mock import MagicMock
+        from woom.job import JobStatus
+
+        minimal_config['cycles']['end_date'] = '2020-01-04'
+        minimal_config['cycles']['freq'] = '1D'
+        minimal_config['stages']['cycles'] = {'seq': ['taskA']}
+        minimal_config.filename = str(tmp_path / 'workflow.cfg')
+
+        mock_task = Mock()
+        mock_task.is_skipped = False
+        mock_task.is_blocking = True
+        mock_task.name = 'taskA'
+        mock_taskmanager.get_task.return_value = mock_task
+        mock_taskmanager.host.get_jobmanager.return_value.with_scheduler = None
+
+        workflow = Workflow(minimal_config, mock_taskmanager)
+        assert len(workflow.cycles) == 3
+
+        submitted_depends = []
+        job_counter = [0]
+
+        def fake_submit(depend, blocking):
+            job_counter[0] += 1
+            job = Mock()
+            job.__str__ = Mock(return_value=str(job_counter[0]))
+            submitted_depends.append(list(depend))
+            return job
+
+        # Cycle 0: run, cycle 1: skip, cycle 2: run
+        call_index = [0]
+
+        def is_skipped(task_name):
+            idx = call_index[0]
+            call_index[0] += 1
+            return idx == 1
+
+        with patch.object(workflow, 'is_task_skipped', side_effect=is_skipped), \
+             patch.object(workflow, 'get_task_status', return_value=JobStatus['NOTSUBMITTED']), \
+             patch.object(workflow, 'clean_task'), \
+             patch.object(workflow, 'submit_task_fake', side_effect=fake_submit), \
+             patch.object(workflow, 'set_context', return_value=MagicMock()), \
+             patch.object(workflow, 'terminate_blocking_jobs'):
+            workflow.run(dry=True)
+
+        assert len(submitted_depends) == 2, "Cycles 1 and 3 should each submit one job"
+        assert submitted_depends[0] == [], "Cycle 1 has no prior dependency"
+        assert len(submitted_depends[1]) == 1, "Cycle 3 must depend on cycle 1's job (not empty)"
+
+    def test_skip_preserves_intragroup_task_depend(self, minimal_config, mock_taskmanager, tmp_path):
+        """When task A is skipped inside a group [A, B], task B still depends on the previous sequence"""
+        from unittest.mock import MagicMock
+        from woom.job import JobStatus
+
+        # seq1 runs taskPre, seq2 runs group [taskA (skipped), taskB]
+        minimal_config['cycles']['end_date'] = '2020-01-02'
+        minimal_config['stages']['cycles'] = {
+            'seq1': ['taskPre'],
+            'seq2': ['mygroup'],
+        }
+        minimal_config['groups'] = {'mygroup': ['taskA', 'taskB']}
+        minimal_config.filename = str(tmp_path / 'workflow.cfg')
+
+        mock_task = Mock()
+        mock_task.is_skipped = False
+        mock_task.is_blocking = True
+        mock_task.name = 'task'
+        mock_taskmanager.get_task.return_value = mock_task
+        mock_taskmanager.host.get_jobmanager.return_value.with_scheduler = None
+
+        workflow = Workflow(minimal_config, mock_taskmanager)
+        assert len(workflow.cycles) == 1
+
+        submitted_depends = {}
+        job_counter = [0]
+
+        def fake_submit(depend, blocking):
+            job_counter[0] += 1
+            job = Mock()
+            job.__str__ = Mock(return_value=str(job_counter[0]))
+            return job
+
+        def fake_submit_tracking(task_name):
+            def _submit(depend, blocking):
+                job_counter[0] += 1
+                job = Mock()
+                job.__str__ = Mock(return_value=str(job_counter[0]))
+                submitted_depends[task_name] = list(depend)
+                return job
+            return _submit
+
+        # is_task_skipped: True only for taskA
+        def is_skipped(task_name):
+            return task_name == 'taskA'
+
+        # submit_task_fake called in order: taskPre, taskB (taskA is skipped)
+        call_order = ['taskPre', 'taskB']
+        submit_index = [0]
+
+        def fake_submit_ordered(depend, blocking):
+            name = call_order[submit_index[0]]
+            submit_index[0] += 1
+            job_counter[0] += 1
+            job = Mock()
+            job.__str__ = Mock(return_value=str(job_counter[0]))
+            submitted_depends[name] = list(depend)
+            return job
+
+        with patch.object(workflow, 'is_task_skipped', side_effect=is_skipped), \
+             patch.object(workflow, 'get_task_status', return_value=JobStatus['NOTSUBMITTED']), \
+             patch.object(workflow, 'clean_task'), \
+             patch.object(workflow, 'submit_task_fake', side_effect=fake_submit_ordered), \
+             patch.object(workflow, 'set_context', return_value=MagicMock()), \
+             patch.object(workflow, 'terminate_blocking_jobs'):
+            workflow.run(dry=True)
+
+        assert 'taskPre' in submitted_depends
+        assert 'taskB' in submitted_depends
+        assert submitted_depends['taskPre'] == [], "taskPre has no prior dependency"
+        assert len(submitted_depends['taskB']) == 1, "taskB must depend on taskPre's job (not empty)"

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -911,9 +911,7 @@ class TestWorkflowSkip:
 class TestWorkflowForce:
     """Test force/no-force behaviour on second run"""
 
-    def test_successful_task_not_resubmitted_without_force(
-        self, minimal_config, mock_taskmanager, tmp_path
-    ):
+    def test_successful_task_not_resubmitted_without_force(self, minimal_config, mock_taskmanager, tmp_path):
         """A task with SUCCESS status must not be re-submitted when force=False (default)"""
         from unittest.mock import MagicMock
 
@@ -951,9 +949,7 @@ class TestWorkflowForce:
 
         assert submit_calls == [], "Task already in SUCCESS must not be re-submitted when force=False"
 
-    def test_successful_task_resubmitted_with_force(
-        self, minimal_config, mock_taskmanager, tmp_path
-    ):
+    def test_successful_task_resubmitted_with_force(self, minimal_config, mock_taskmanager, tmp_path):
         """A task with SUCCESS status must be re-submitted when force=True"""
         from unittest.mock import MagicMock
 

--- a/woom/workflow.py
+++ b/woom/workflow.py
@@ -759,7 +759,7 @@ class Workflow:
                                     )
 
                                 if not force:
-                                    if status.name is wjob.JobStatus.SUCCESS:
+                                    if status is wjob.JobStatus.SUCCESS:
                                         self.logger.debug(f"Task already succeeded. Skipping: {long_task}")
                                         continue
 

--- a/woom/workflow.py
+++ b/woom/workflow.py
@@ -804,19 +804,21 @@ class Workflow:
                                         task_jobs.append(job)
 
                             # Dependencies for the next task in the group
-                            task_depend = task_jobs
+                            if task_jobs:
+                                task_depend = task_jobs
 
                         # The last jobs of this group are added to sequence jobs
                         sequence_jobs.extend(task_jobs)
 
                     # Dependencies for the next sequence
-                    sequence_depend = sequence_jobs
+                    if sequence_jobs:
+                        sequence_depend = sequence_jobs
 
                 # Stage jobs
                 if stage == "cycles" and self._cycles_indep:  # parallel independant cycles
                     stage_jobs.extend(sequence_jobs)
                 else:
-                    stage_jobs = sequence_jobs
+                    stage_jobs = sequence_depend
 
                 if stage == "cycles":
                     self.logger.info("Successfully submitted cycle: " + cycle.label)


### PR DESCRIPTION
Closes #39

# Description

When tasks were skipped via `--skip` or `[stages] skip`, the job dependency chain between cycles was silently broken. Tasks in cycle N+1 lost their dependency on cycle N's jobs whenever cycle N was entirely skipped, allowing cycles to run out of order on the scheduler.

The same issue affected sequential task groups: if task A in `[A -> B]` was skipped, task B lost the dependency on the previous sequence's jobs.

**Root cause** — three assignments in `Workflow.run()` unconditionally overwrote dependency lists with an empty list when no jobs were submitted:

```python
task_depend = task_jobs          # [] when task was skipped
sequence_depend = sequence_jobs  # [] when whole cycle was skipped
stage_jobs = sequence_jobs       # [] propagated to epilog
```

**Fix** — only update each variable when jobs were actually submitted; fall back to the preserved value otherwise:

```python
if task_jobs:
    task_depend = task_jobs
if sequence_jobs:
    sequence_depend = sequence_jobs
stage_jobs = sequence_depend     # use the preserved value
```

# Check list

- [x] Closes #39
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `CHANGES.rst`
- [ ] New modules are listed in `api.rst`