### PR TITLE
feat: add --tasks option to run only selected tasks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ New features
   or at runtime with ``skip = task1 task2`` in ``[stages]`` of
   :file:`workflow.cfg`, or via ``woom run --skip task1 task2`` on the CLI.
   Skipped tasks appear as ``SKIPPED`` (bold cyan) in ``woom show status`` [:pull:`35`].
+* Add the ``woom run --tasks task1 task2`` option, the opposite of ``--skip``:
+  only the listed tasks are submitted, all others are kept in the task tree
+  (without being submitted) so their artifacts remain accessible. ``--tasks``
+  and ``--skip`` are mutually exclusive [:issue:`45`].
 * Add the ``woom monitor`` command: a lightweight Flask-based web UI for launching,
   monitoring, and stopping workflows from a browser.  Features include a live log
   stream (SSE), artifact browser with download links, an interactive crontab scheduler

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,10 +13,12 @@ New features
   or at runtime with ``skip = task1 task2`` in ``[stages]`` of
   :file:`workflow.cfg`, or via ``woom run --skip task1 task2`` on the CLI.
   Skipped tasks appear as ``SKIPPED`` (bold cyan) in ``woom show status`` [:pull:`35`].
-* Add the ``woom run --tasks task1 task2`` option, the opposite of ``--skip``:
-  only the listed tasks are submitted, all others are kept in the task tree
-  (without being submitted) so their artifacts remain accessible. ``--tasks``
-  and ``--skip`` are mutually exclusive [:issue:`45`].
+* Add the ability to run only selected tasks, the opposite of skip: set
+  ``tasks = task1 task2`` in ``[stages]`` of :file:`workflow.cfg`, or pass
+  ``woom run --tasks task1 task2`` on the CLI (the CLI list overrides the
+  config one, unlike ``--skip`` which merges with it). All other tasks are
+  kept in the task tree (without being submitted) so their artifacts remain
+  accessible. ``--tasks`` and ``--skip`` are mutually exclusive [:issue:`45`].
 * Add the ``woom monitor`` command: a lightweight Flask-based web UI for launching,
   monitoring, and stopping workflows from a browser.  Features include a live log
   stream (SSE), artifact browser with download links, an interactive crontab scheduler

--- a/docs/indepth_workflow.rst
+++ b/docs/indepth_workflow.rst
@@ -439,12 +439,32 @@ exclude, you list the only tasks to submit. All other tasks are kept in the
 task tree (without being submitted) so their artifact paths remain
 accessible to downstream tasks, exactly like a skipped task.
 
+**In :file:`workflow.cfg`** (persisted task list for a given experiment):
+
+.. code-block:: ini
+
+    [stages]
+        tasks = run_model
+
+        [[prolog]]
+        setup = preprocess, download_forcings, compile_model
+
+        [[cycles]]
+        run = run_model
+
+Only ``run_model`` is submitted; ``preprocess``, ``download_forcings`` and
+``compile_model`` are kept in the task tree but not submitted.
+
+**On the command line** (one-off override):
+
 .. code-block:: bash
 
     woom run --tasks run_model
 
-Multiple task names are space-separated. ``--tasks`` and ``--skip`` are
-mutually exclusive: combining them on the command line raises an error.
+Multiple task names are space-separated. Unlike ``--skip``, the CLI list
+**overrides** (rather than merges with) any names already listed in
+``[stages] tasks``. ``--tasks`` and ``--skip`` are mutually exclusive:
+combining them on the command line raises an error.
 
 Custom Parameters
 =================

--- a/docs/indepth_workflow.rst
+++ b/docs/indepth_workflow.rst
@@ -431,6 +431,21 @@ already listed in ``[stages] skip``, so you can combine both mechanisms.
    use the ``skip = True`` option directly in :file:`tasks.cfg`
    (see :ref:`indepth.tasks`).
 
+Running Only Some Tasks
+------------------------
+
+``--tasks`` is the opposite of ``--skip``: instead of listing the tasks to
+exclude, you list the only tasks to submit. All other tasks are kept in the
+task tree (without being submitted) so their artifact paths remain
+accessible to downstream tasks, exactly like a skipped task.
+
+.. code-block:: bash
+
+    woom run --tasks run_model
+
+Multiple task names are space-separated. ``--tasks`` and ``--skip`` are
+mutually exclusive: combining them on the command line raises an error.
+
 Custom Parameters
 =================
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -728,11 +728,19 @@ class TestWorkflowSkip:
         assert workflow.is_task_skipped('task1') is False
 
     def test_only_tasks_list_empty_by_default(self, minimal_config, mock_taskmanager, tmp_path):
-        """_only_tasks defaults to empty list"""
+        """_only_tasks defaults to empty list when not in config"""
         minimal_config.filename = str(tmp_path / 'workflow.cfg')
         workflow = Workflow(minimal_config, mock_taskmanager)
 
         assert workflow._only_tasks == []
+
+    def test_only_tasks_list_loaded_from_config(self, minimal_config, mock_taskmanager, tmp_path):
+        """_only_tasks is populated from workflow config [stages] tasks"""
+        minimal_config['stages']['tasks'] = ['task_a', 'task_b']
+        minimal_config.filename = str(tmp_path / 'workflow.cfg')
+        workflow = Workflow(minimal_config, mock_taskmanager)
+
+        assert workflow._only_tasks == ['task_a', 'task_b']
 
     def test_run_sets_only_tasks_list(self, minimal_config, mock_taskmanager, tmp_path):
         """workflow.run(tasks=[...]) sets _only_tasks"""
@@ -745,6 +753,19 @@ class TestWorkflowSkip:
         workflow.run(tasks=['task_a'])
 
         assert workflow._only_tasks == ['task_a']
+
+    def test_run_cli_tasks_overrides_config_tasks(self, minimal_config, mock_taskmanager, tmp_path):
+        """workflow.run(tasks=[...]) overrides (not merges with) the config-defined list"""
+        minimal_config['stages']['tasks'] = ['task_a']
+        minimal_config.filename = str(tmp_path / 'workflow.cfg')
+        workflow = Workflow(minimal_config, mock_taskmanager)
+
+        # Empty task tree + no scheduler → run() completes without submission
+        mock_taskmanager.host.get_jobmanager.return_value.with_scheduler = None
+        mock_taskmanager.host.get_jobmanager.return_value.jobs = []
+        workflow.run(tasks=['task_b'])
+
+        assert workflow._only_tasks == ['task_b']
 
     def test_skip_list_loaded_from_config(self, minimal_config, mock_taskmanager, tmp_path):
         """_skip_tasks is populated from workflow config [stages] skip"""

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -705,6 +705,47 @@ class TestWorkflowSkip:
 
         assert workflow.is_task_skipped('task1') is False
 
+    def test_is_task_skipped_via_only_tasks_list(self, minimal_config, mock_taskmanager, tmp_path):
+        """is_task_skipped returns True when an only-tasks list is set and the task is absent from it"""
+        minimal_config.filename = str(tmp_path / 'workflow.cfg')
+        mock_task = Mock()
+        mock_task.is_skipped = False
+        mock_taskmanager.get_task.return_value = mock_task
+        workflow = Workflow(minimal_config, mock_taskmanager)
+        workflow._only_tasks = ['task2']
+
+        assert workflow.is_task_skipped('task1') is True
+
+    def test_is_task_skipped_false_when_in_only_tasks_list(self, minimal_config, mock_taskmanager, tmp_path):
+        """is_task_skipped returns False when an only-tasks list is set and the task is in it"""
+        minimal_config.filename = str(tmp_path / 'workflow.cfg')
+        mock_task = Mock()
+        mock_task.is_skipped = False
+        mock_taskmanager.get_task.return_value = mock_task
+        workflow = Workflow(minimal_config, mock_taskmanager)
+        workflow._only_tasks = ['task1']
+
+        assert workflow.is_task_skipped('task1') is False
+
+    def test_only_tasks_list_empty_by_default(self, minimal_config, mock_taskmanager, tmp_path):
+        """_only_tasks defaults to empty list"""
+        minimal_config.filename = str(tmp_path / 'workflow.cfg')
+        workflow = Workflow(minimal_config, mock_taskmanager)
+
+        assert workflow._only_tasks == []
+
+    def test_run_sets_only_tasks_list(self, minimal_config, mock_taskmanager, tmp_path):
+        """workflow.run(tasks=[...]) sets _only_tasks"""
+        minimal_config.filename = str(tmp_path / 'workflow.cfg')
+        workflow = Workflow(minimal_config, mock_taskmanager)
+
+        # Empty task tree + no scheduler → run() completes without submission
+        mock_taskmanager.host.get_jobmanager.return_value.with_scheduler = None
+        mock_taskmanager.host.get_jobmanager.return_value.jobs = []
+        workflow.run(tasks=['task_a'])
+
+        assert workflow._only_tasks == ['task_a']
+
     def test_skip_list_loaded_from_config(self, minimal_config, mock_taskmanager, tmp_path):
         """_skip_tasks is populated from workflow config [stages] skip"""
         minimal_config['stages']['skip'] = ['task_a', 'task_b']

--- a/woom/cli.py
+++ b/woom/cli.py
@@ -398,10 +398,21 @@ def add_parser_run(subparsers):
         help="do not run if it has already been run",
         action="store_true",
     )
-    parser_run.add_argument(
+    skip_or_tasks = parser_run.add_mutually_exclusive_group()
+    skip_or_tasks.add_argument(
         "--skip",
         help=(
             "task names to skip: not submitted but kept in the task treeso their artifacts remain accessible"
+        ),
+        nargs="+",
+        metavar="TASK",
+        default=[],
+    )
+    skip_or_tasks.add_argument(
+        "--tasks",
+        help=(
+            "only run these task names: all other tasks are not submitted but kept in the "
+            "task tree so their artifacts remain accessible"
         ),
         nargs="+",
         metavar="TASK",
@@ -422,7 +433,7 @@ def main_run(parser, args):
     # Run the workflow
     logger.debug("Run the workflow")
     try:
-        workflow.run(dry=args.dry_run, force=args.force, skip=args.skip)
+        workflow.run(dry=args.dry_run, force=args.force, skip=args.skip, tasks=args.tasks)
     except Exception as e:
         logger.exception(f"Workflow failed: {e.args[0]}")
         return 1

--- a/woom/workflow.ini
+++ b/woom/workflow.ini
@@ -41,6 +41,7 @@ dry_run=boolean(default=False)
 update=boolean(default=False)
 sentinel_check_interval=integer(default=10)
 skip=force_list(default=list()) # task names to skip at runtime (not submitted, kept in tree)
+tasks=force_list(default=list()) # task names to exclusively run at runtime (others not submitted, kept in tree)
 
     [[prolog]] # sequences before looping on cycles
     __many__=force_list # list of parallel tasks or groups

--- a/woom/workflow.py
+++ b/woom/workflow.py
@@ -99,8 +99,8 @@ class Workflow:
         # Tasks to skip (from workflow.cfg [stages] skip)
         self._skip_tasks = list(self._config["stages"].get("skip") or [])
 
-        # Tasks to exclusively run (from --tasks on the CLI)
-        self._only_tasks = []
+        # Tasks to exclusively run (from workflow.cfg [stages] tasks, overridden by --tasks on the CLI)
+        self._only_tasks = list(self._config["stages"].get("tasks") or [])
 
         # Other paths
         self._paths = {
@@ -288,8 +288,9 @@ class Workflow:
         A task is skipped when its ``skip`` flag is set to ``True`` in
         :file:`tasks.cfg`, when its name appears in the runtime skip list
         (``[stages] skip`` in :file:`workflow.cfg` or ``--skip`` on the CLI),
-        or when a runtime list of tasks to exclusively run is set (``--tasks``
-        on the CLI) and its name is not in that list.
+        or when a list of tasks to exclusively run is set (``[stages] tasks``
+        in :file:`workflow.cfg`, overridden by ``--tasks`` on the CLI) and its
+        name is not in that list.
 
         Skipped tasks are never submitted but remain in the task tree so that
         their artifact paths are still accessible to downstream tasks.

--- a/woom/workflow.py
+++ b/woom/workflow.py
@@ -99,6 +99,9 @@ class Workflow:
         # Tasks to skip (from workflow.cfg [stages] skip)
         self._skip_tasks = list(self._config["stages"].get("skip") or [])
 
+        # Tasks to exclusively run (from --tasks on the CLI)
+        self._only_tasks = []
+
         # Other paths
         self._paths = {
             "PATH": os.path.join(self._workflow_dir, "bin"),
@@ -283,12 +286,16 @@ class Workflow:
         """Is this task skipped?
 
         A task is skipped when its ``skip`` flag is set to ``True`` in
-        :file:`tasks.cfg`, or when its name appears in the runtime skip list
-        (``[stages] skip`` in :file:`workflow.cfg` or ``--skip`` on the CLI).
+        :file:`tasks.cfg`, when its name appears in the runtime skip list
+        (``[stages] skip`` in :file:`workflow.cfg` or ``--skip`` on the CLI),
+        or when a runtime list of tasks to exclusively run is set (``--tasks``
+        on the CLI) and its name is not in that list.
 
         Skipped tasks are never submitted but remain in the task tree so that
         their artifact paths are still accessible to downstream tasks.
         """
+        if self._only_tasks and task_name not in self._only_tasks:
+            return True
         return self.get_task(task_name).is_skipped or task_name in self._skip_tasks
 
     def get_task_items(self, getter, task_name, cycle=None, member=None, flat=False, **kwargs):
@@ -660,12 +667,14 @@ class Workflow:
                     os.remove(fname)
                 self.logger.debug(f"Removed: {fname}")
 
-    def run(self, dry=False, force=False, skip=None):
+    def run(self, dry=False, force=False, skip=None, tasks=None):
         """Run the workflow by submiting all tasks"""
         self._dry = dry
         self._force = force
         if skip:
             self._skip_tasks = list(set(self._skip_tasks) | set(skip))
+        if tasks:
+            self._only_tasks = list(tasks)
         if dry:
             self.logger.debug("Running the workflow in fake mode")
         if force:


### PR DESCRIPTION
# Description

Add a --tasks option to woom run, the opposite of --skip: tasks not listed are kept in the task tree (artifacts stay accessible) but not submitted. --tasks and --skip are mutually exclusive on the CLI.

# Check list

- [x] Closes #45
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `CHANGES.rst`
- [ ] New modules are listed in `api.rst`
